### PR TITLE
feat(nvim,zsh): migrate AI to avante.nvim with opencode-go provider

### DIFF
--- a/config/nvim/lua/community.lua
+++ b/config/nvim/lua/community.lua
@@ -15,4 +15,5 @@ return {
     { import = "astrocommunity.lsp.lspsaga-nvim" },
     { import = "astrocommunity.motion.nvim-surround" },
     { import = "astrocommunity.motion.flash-nvim" },
+    { import = "astrocommunity.ai.avante-nvim" },
 }

--- a/config/nvim/lua/plugins/ai.lua
+++ b/config/nvim/lua/plugins/ai.lua
@@ -1,210 +1,60 @@
-local function filter_ai_trigger()
-    local filename = vim.fn.expand "%:t"
-    if filename:match "%.localrc" or filename:match "%.env" or filename:match "%.json" then return false end
-    return true
-end
-
+---@type LazySpec
 return {
     {
-        "zbirenbaum/copilot.lua",
-        cmd = "Copilot",
-        build = ":Copilot auth",
-        event = "BufReadPost",
+        "yetone/avante.nvim",
         opts = {
-            suggestion = { enabled = false },
-            panel = { enabled = false },
-        },
-        specs = {
-            "saghen/blink.cmp",
-            optional = true,
-            dependencies = { "giuxtaposition/blink-cmp-copilot" },
-            opts = {
-                sources = {
-                    default = { "copilot" },
-                    providers = {
-                        copilot = {
-                            name = "copilot",
-                            module = "blink-cmp-copilot",
-                            score_offset = 100,
-                            async = true,
-                            enabled = filter_ai_trigger,
-                        },
+            provider = "opencode-go",
+            providers = {
+                ["opencode-go"] = {
+                    __inherited_from = "openai",
+                    endpoint = "https://opencode.ai/zen/go/v1",
+                    model = "deepseek-v4-pro",
+                    api_key_name = "OPENCODE_GO_API_KEY",
+                    list_models = {
+                        { id = "glm-5.1", name = "opencode-go: GLM-5.1" },
+                        { id = "glm-5", name = "opencode-go: GLM-5" },
+                        { id = "kimi-k2.7", name = "opencode-go: Kimi K2.7" },
+                        { id = "kimi-k2.6", name = "opencode-go: Kimi K2.6" },
+                        { id = "deepseek-v4-pro", name = "opencode-go: DeepSeek V4 Pro" },
+                        { id = "deepseek-v4-flash", name = "opencode-go: DeepSeek V4 Flash" },
+                        { id = "mimo-v2.5", name = "opencode-go: MiMo V2.5" },
+                        { id = "mimo-v2.5-pro", name = "opencode-go: MiMo V2.5 Pro" },
                     },
+                },
+                ["opencode-anthropic"] = {
+                    __inherited_from = "claude",
+                    endpoint = "https://opencode.ai/zen/go",
+                    model = "minimax-m3",
+                    api_key_name = "OPENCODE_GO_API_KEY",
+                    list_models = {
+                        { id = "minimax-m3", name = "opencode-anthropic: MiniMax M3" },
+                        { id = "minimax-m2.7", name = "opencode-anthropic: MiniMax M2.7" },
+                        { id = "minimax-m2.5", name = "opencode-anthropic: MiniMax M2.5" },
+                        { id = "qwen3.7-max", name = "opencode-anthropic: Qwen3.7 Max" },
+                        { id = "qwen3.7-plus", name = "opencode-anthropic: Qwen3.7 Plus" },
+                        { id = "qwen3.6-plus", name = "opencode-anthropic: Qwen3.6 Plus" },
+                    },
+                },
+                claude = {
+                    endpoint = "https://api.anthropic.com",
+                    model = "claude-sonnet-4-20250514",
+                    timeout = 30000,
+                    extra_request_body = {
+                        temperature = 0.75,
+                        max_tokens = 20480,
+                    },
+                },
+                openai = {
+                    endpoint = "https://api.openai.com",
+                    model = "gpt-4o",
+                    timeout = 30000,
+                },
+                moonshot = {
+                    endpoint = "https://api.moonshot.ai/v1",
+                    model = "kimi-k2-0711-preview",
+                    timeout = 30000,
                 },
             },
         },
-    },
-
-    {
-        "supermaven-inc/supermaven-nvim",
-        opts = {
-            disable_inline_completion = true, -- disables inline completion for use with cmp
-            disable_keymaps = true, -- disables built in keymaps for more manual control
-            condition = filter_ai_trigger,
-        },
-        specs = {
-            "saghen/blink.cmp",
-            optional = true,
-            dependencies = { "huijiro/blink-cmp-supermaven" },
-            opts = {
-                sources = {
-                    default = { "supermaven" },
-                    providers = {
-                        supermaven = {
-                            name = "supermaven",
-                            module = "blink-cmp-supermaven",
-                            score_offset = 99,
-                            async = true,
-                            enabled = filter_ai_trigger,
-                        },
-                    },
-                },
-            },
-        },
-    },
-
-    {
-        "Exafunction/windsurf.nvim",
-        dependencies = {
-            "nvim-lua/plenary.nvim",
-        },
-        config = function()
-            require("codeium").setup {
-                enable_chat = false,
-            }
-        end,
-        specs = {
-            "saghen/blink.cmp",
-            optional = true,
-            opts = {
-                sources = {
-                    default = { "codeium" },
-                    providers = {
-                        codeium = {
-                            name = "Codeium",
-                            module = "codeium.blink",
-                            max_items = 3,
-                            async = true,
-                            enabled = filter_ai_trigger,
-                        },
-                    },
-                },
-            },
-        },
-    },
-
-    -- {
-    --     "milanglacier/minuet-ai.nvim",
-    --     enabled = false,
-    --     config = function()
-    --         require("minuet").setup {
-    --             n_completions = 1,
-    --             provider = "codestral",
-    --             provider_options = {
-    --                 codestral = {
-    --                     optional = {
-    --                         temperature = 0.0,
-    --                         max_tokens = 256,
-    --                         stop = { "\n\n" },
-    --                     },
-    --                 },
-    --
-    --                 openai_fim_compatible = {
-    --                     api_key = "DEEPSEEK_API_KEY",
-    --                     name = "deepseek",
-    --                     optional = {
-    --                         temperature = 0.0,
-    --                         max_tokens = 256,
-    --                     },
-    --                 },
-    --
-    --                 openai_compatible = {
-    --                     end_point = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
-    --                     api_key = "DASHSCOPE_API_KEY",
-    --                     name = "qwen",
-    --                     model = "qwen3-coder-flash",
-    --                     optional = {
-    --                         max_tokens = 256,
-    --                         temperature = 0.0,
-    --                     },
-    --                 },
-    --             },
-    --         }
-    --     end,
-    --     specs = {
-    --         {
-    --             "saghen/blink.cmp",
-    --             optional = true,
-    --             opts = {
-    --                 sources = {
-    --                     default = { "minuet" },
-    --                     providers = {
-    --                         minuet = {
-    --                             name = "minuet",
-    --                             module = "minuet.blink",
-    --                             async = true,
-    --                             timeout_ms = 3000,
-    --                             score_offset = 50, -- Gives minuet higher priority among suggestions
-    --                             enabled = filter_ai_trigger,
-    --                         },
-    --                     },
-    --                 },
-    --             },
-    --         },
-    --     },
-    -- },
-    {
-        "NickvanDyke/opencode.nvim",
-        dependencies = {
-            -- Recommended for `ask()` and `select()`.
-            -- Required for `snacks` provider.
-            ---@module 'snacks' <- Loads `snacks.nvim` types for configuration intellisense.
-            { "folke/snacks.nvim", opts = { input = {}, picker = {}, terminal = {} } },
-        },
-        config = function()
-            ---@type opencode.Opts
-            vim.g.opencode_opts = {
-                -- Your configuration, if any — see `lua/opencode/config.lua`, or "goto definition" on the type or field.
-                provider = {
-                    enabled = "snacks",
-                },
-            }
-
-            -- Required for `opts.events.reload`.
-            vim.o.autoread = true
-
-            -- Recommended/example keymaps.
-            vim.keymap.set(
-                { "n", "x" },
-                "<Leader>aa",
-                function() require("opencode").ask("@this: ", { submit = true }) end,
-                { desc = "Ask opencode…" }
-            )
-            vim.keymap.set(
-                { "n", "x" },
-                "<Leader>ax",
-                function() require("opencode").select() end,
-                { desc = "Execute opencode action…" }
-            )
-            vim.keymap.set(
-                { "n" },
-                "<leader>ao",
-                function() require("opencode").toggle() end,
-                { desc = "Toggle opencode" }
-            )
-
-            vim.keymap.set(
-                { "n", "x" },
-                "go",
-                function() return require("opencode").operator "@this " end,
-                { desc = "Add range to opencode", expr = true }
-            )
-            vim.keymap.set(
-                "n",
-                "goo",
-                function() return require("opencode").operator "@this " .. "_" end,
-                { desc = "Add line to opencode", expr = true }
-            )
-        end,
     },
 }

--- a/config/nvim/lua/plugins/astrocore.lua
+++ b/config/nvim/lua/plugins/astrocore.lua
@@ -120,20 +120,6 @@ return {
                 },
             },
 
-            copilot_chat = {
-                {
-                    event = "BufEnter",
-                    pattern = "copilot-*",
-                    callback = function()
-                        -- Set buffer-local options
-                        vim.opt_local.relativenumber = false
-                        vim.opt_local.number = false
-                        vim.opt_local.conceallevel = 0
-                        vim.opt_local.foldcolumn = "0"
-                    end,
-                },
-            },
-
             c_commentstring = {
                 {
                     event = "FileType",

--- a/config/nvim/lua/plugins/user.lua
+++ b/config/nvim/lua/plugins/user.lua
@@ -349,7 +349,7 @@ return {
         "MeanderingProgrammer/render-markdown.nvim",
         dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-mini/mini.icons" },
         opts = {
-            file_types = { "markdown", "copilot-chat" },
+            file_types = { "markdown", "Avante" },
             completions = { blink = { enabled = true } },
         },
     },

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -124,3 +124,12 @@ done
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 # If a ~/.localrc zshrc exists, source it
 [[ -a ~/.localrc ]] && source ~/.localrc
+
+# Load OpenCode Go API key from opencode CLI's auth.json (avante.nvim consumes it)
+if [[ -f "$HOME/.local/share/opencode/auth.json" ]] && command -v jq >/dev/null 2>&1; then
+  _opencode_key=$(jq -r '."opencode-go".key // empty' "$HOME/.local/share/opencode/auth.json" 2>/dev/null)
+  if [[ -n "$_opencode_key" && "$_opencode_key" != "null" ]]; then
+    export OPENCODE_GO_API_KEY="$_opencode_key"
+  fi
+  unset _opencode_key
+fi


### PR DESCRIPTION
## Summary
- Replace copilot/supermaven/windsurf/opencode with avante.nvim
- Configure opencode-go and opencode-anthropic providers with multiple model options
- Auto-load OPENCODE_GO_API_KEY from opencode CLI's auth.json in zshrc

## Changes
- **community.lua** — added avante-nvim community import
- **ai.lua** — simplified from 4 AI plugins to a single avante.nvim config
- **astrocore.lua** — removed stale copilot_chat autocommands
- **user.lua** — updated render-markdown filetype from copilot-chat to Avante
- **zshrc.symlink** — auto-loads OpenCode Go API key from opencode CLI auth file