### PR TITLE
feat: add atuin shell history with local-only config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ lazy-lock.json
 config/kitty/kitty-overrides.conf
 config/tmux/plugins
 zsh/.oh-my-zsh
+# Atuin local data (history db, encryption key, session) — never commit
+config/atuin/key
+config/atuin/session
+config/atuin/*.db
+config/atuin/history.db*

--- a/Brewfile
+++ b/Brewfile
@@ -57,3 +57,4 @@ brew "htop"
 brew "gemini-cli"
 brew "copilot-cli"
 brew "git-delta"
+brew "atuin" # magical shell history (replaces fzf Ctrl-R history search)

--- a/README.md
+++ b/README.md
@@ -260,6 +260,56 @@ work. To set this, you can use the `~/.localrc` file to set it in the following 
 export TMUX_MINIMAL=1
 ```
 
+## Atuin (shell history)
+
+[Atuin](https://github.com/atuinsh/atuin) replaces shell history with a searchable, syncable SQLite database. This setup runs **local-only** (no cloud account); search uses fzf-style fuzzy matching to match the existing fzf workflow.
+
+### Installation
+
+Atuin is listed in the [Brewfile](./Brewfile) and installed by `./install.sh homebrew`. The config is symlinked to `~/.config/atuin/config.toml` by `./install.sh link`, and the zsh integration (`zsh/atuin.zsh`) is auto-sourced by `zshrc.symlink`.
+
+### Keybindings
+
+| Key | Action |
+| --- | --- |
+| `Ctrl-R` | Open Atuin fuzzy search UI (replaces fzf history search) |
+| `Up` | Cycle history filtered to the current directory |
+| `Ctrl-R` (inside UI) | Cycle filter modes: global → host → session → directory → workspace |
+| `Tab` | Copy selected command to the command line for editing |
+| `Enter` | Execute the selected command immediately (`enter_accept = true`) |
+| `Esc` | Restore the original command line |
+| `Ctrl-A` then `D` | Delete the selected history entry (prefix mode) |
+| `Ctrl-T` / `Alt-C` | Still fzf file / directory search (unaffected by Atuin) |
+
+Prefix a command with a space to keep it out of history (ignorespace).
+
+### Common CLI
+
+```bash
+atuin search <query>      # search history from the command line
+atuin history list        # list recorded history
+atuin stats               # show shell usage statistics
+atuin doctor              # diagnose shell integration
+atuin import auto         # import existing shell history (run once)
+atuin history prune       # remove entries matching history_filter / cwd_filter
+```
+
+### Enabling cloud sync later (optional)
+
+This setup is local-only. To enable cross-machine encrypted sync later:
+
+1. Add to `~/.config/atuin/config.toml`:
+   ```toml
+   auto_sync = true
+   [sync]
+   records = true
+   ```
+2. `atuin register -u <username> -e <email>`
+3. Save the encryption key printed by `atuin key` to a safe location.
+4. `atuin sync`
+
+See the [Atuin docs](https://docs.atuin.sh/) for full reference.
+
 ## Docker Setup
 
 A Dockerfile exists in the repository as a testing ground for linux support. To set up the image, make sure you have Docker installed and then run the following command.

--- a/config/atuin/config.toml
+++ b/config/atuin/config.toml
@@ -1,0 +1,43 @@
+# Atuin config — local-only history (no cloud sync)
+# Docs: https://docs.atuin.sh/cli/configuration/config/
+# Symlinked to ~/.config/atuin/config.toml by `install.sh link`.
+
+# --- Sync ---
+auto_sync = false          # local-only mode, do not connect to api.atuin.sh
+update_check = false       # version managed by Homebrew
+
+# --- Search ---
+search_mode = "fuzzy"                         # fzf-style fuzzy match
+filter_mode = "global"                        # default: search full history; cycle with Ctrl-R in UI
+search_mode_shell_up_key_binding = "fuzzy"    # Up arrow uses fuzzy
+filter_mode_shell_up_key_binding = "directory"# Up arrow defaults to current-directory filter
+inline_height_shell_up_key_binding = 10
+
+# --- UI ---
+style = "auto"             # full when room allows, compact otherwise
+inline_height = 20         # max lines in compact mode
+show_preview = true        # preview commands longer than terminal width
+max_preview_height = 4
+show_help = true
+show_tabs = true
+
+# --- Behavior ---
+enter_accept = true        # Enter executes the selected command; Tab returns it for editing
+exit_mode = "return-original"  # Esc restores the pre-search command line
+keymap_mode = "auto"       # follow the shell's current keymap (vim/emacs)
+store_failed = true        # record commands with non-zero exit status
+secrets_filter = true      # block AWS/GH/Slack/etc keys from being stored
+
+# --- History filter (these commands are never recorded) ---
+# Patterns are unanchored regex; use ^...$ for exact matches.
+history_filter = [
+    "^ls$",
+    "^cd $",
+    "^pwd$",
+    "^clear$",
+    "^exit$",
+]
+
+# --- Dotfiles sync (requires sync v2 + account; disabled for local-only) ---
+[dotfiles]
+enabled = false

--- a/zsh/atuin.zsh
+++ b/zsh/atuin.zsh
@@ -1,0 +1,7 @@
+# Atuin shell integration — magical shell history (https://atuin.sh)
+# This file is auto-sourced by zshrc.symlink AFTER oh-my-zsh, so atuin's
+# Ctrl-R supersedes the fzf plugin's Ctrl-R. fzf's Ctrl-T (files) and
+# Alt-C (directories) are unaffected and still work.
+if command -v atuin >/dev/null 2>&1; then
+  eval "$(atuin init zsh)"
+fi


### PR DESCRIPTION
## Summary

Add [atuin](https://github.com/atuinsh/atuin) for searchable, SQLite-backed shell history, replacing the fzf Ctrl-R history search while keeping fzf's Ctrl-T (files) and Alt-C (directories) intact.

## Changes

| File | Change |
| --- | --- |
| `Brewfile` | Add `atuin` formula (installed via Homebrew/Linuxbrew) |
| `config/atuin/config.toml` | New — local-only mode (no cloud sync), fuzzy search matching existing fzf workflow, secrets filter, history_filter for noisy commands (`ls`, `cd`, `pwd`, `clear`, `exit`) |
| `zsh/atuin.zsh` | New — `eval "$(atuin init zsh)"`, auto-sourced by `zshrc.symlink` **after** oh-my-zsh so atuin's Ctrl-R/Up supersedes the fzf plugin's Ctrl-R |
| `.gitignore` | Exclude atuin local data (key/session/db) — never committed |
| `README.md` | New "Atuin (shell history)" section: keybindings, common CLI, how to enable cloud sync later |

## Keybindings

| Key | Action |
| --- | --- |
| `Ctrl-R` | Atuin fuzzy search UI (replaces fzf history) |
| `Up` | History filtered to current directory |
| `Ctrl-T` / `Alt-C` | fzf file / directory search (unchanged) |
| `Enter` | Execute selected command |
| `Tab` | Edit selected command before running |

## Verification

- [x] `brew install atuin` → v18.16.1
- [x] `./install.sh link` symlinks `config/atuin` → `~/.config/atuin`
- [x] `atuin import auto` imported 10633 zsh history entries
- [x] Fresh interactive zsh: `atuin doctor` reports `shell.preexec: built-in`
- [x] Keybindings confirmed: `Ctrl-R`→`atuin-search`, `Up`→`atuin-up-search`, `Ctrl-T`→`fzf-file-widget`, `Alt-C`→`fzf-cd-widget`

## Config notes

- **Local-only**: `auto_sync = false`; no atuin.sh account required.
- Cloud sync can be enabled later by setting `auto_sync = true`, adding `[sync] records = true`, and running `atuin register` + `atuin sync` (documented in README).
