### PR TITLE
docs(agents): note GitHub Flow workflow and branch protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,11 @@ and have been fixed, but always verify against the source.
 ## Repo shape
 - Personal dotfiles (forked from nicknisi/dotfiles). No build/test/lint/CI,
   no package manifest. Verification is manual: run `install.sh`, open zsh/nvim/tmux.
-- Default branch `main`. Conventional commits (`feat(scope):`, `fix(scope):`,
-  `chore(scope):`, `refactor(scope):`); merged via PRs.
+- Default branch `main` (protected — never push directly). Workflow is GitHub
+  Flow: create a feature branch (`feat/<scope>` or `fix/<scope>`), push it,
+  open a PR with `gh pr create`. Merges on GitHub squash into one commit titled
+  `<PR title> (#N)`. Conventional commits (`feat(scope):`, `fix(scope):`,
+  `chore(scope):`, `refactor(scope):`).
 - Target environment: WSL2 (Ubuntu) + WezTerm + tmux + Neovim.
 
 ## Symlink install model (core mechanism)


### PR DESCRIPTION
## Summary

Updates `AGENTS.md` `Repo shape` section to explicitly document the GitHub Flow workflow.

## Why

During the last sync session, an agent attempted `git push origin main` and was rejected by branch protection — a wasted round-trip that future sessions would repeat. The existing line only said "merged via PRs" without stating:

- `main` is protected (no direct push)
- Branch naming pattern: `feat/<scope>` or `fix/<scope>`
- PR command: `gh pr create`
- Squash merge result: `<PR title> (#N)`

## Change

```diff
- Default branch `main`. Conventional commits (`feat(scope):`, `fix(scope):`,
-   `chore(scope):`, `refactor(scope):`); merged via PRs.
+ Default branch `main` (protected — never push directly). Workflow is GitHub
+   Flow: create a feature branch (`feat/<scope>` or `fix/<scope>`), push it,
+   open a PR with `gh pr create`. Merges on GitHub squash into one commit titled
+   `<PR title> (#N)`. Conventional commits (`feat(scope):`, `fix(scope):`,
+   `chore(scope):`, `refactor(scope):`).
```

Generic GitHub Flow docs are intentionally excluded — only the repo-specific facts an agent would otherwise guess wrong.