### PR TITLE
chore(brew): make Brewfile linux-only; drop mac taps/casks and obsolete core tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,31 +1,16 @@
 # vim:ft=ruby
+#
+# Linux-only Brewfile. macOS-specific entries (cask taps, noti, trash,
+# imageoptim, wezterm/1password casks, font casks, koekeishiya tap)
+# have been removed — target environment is WSL2 Ubuntu per AGENTS.md.
+# To re-add mac entries, fork the upstream nicknisi/dotfiles or restore
+# them from git history.
 
-if OS.mac?
-    # taps
-    tap "homebrew/cask"
-    tap "homebrew/cask-fonts"
-    tap "koekeishiya/formulae"
-
-    brew "noti" # utility to display notifications from scripts
-    brew "trash" # rm, but put in the trash rather than completely delete
-
-    # Applications
-    cask "imageoptim" # a tool to optimize images
-    cask "1password/tap/1password-cli"
-    cask "wezterm" # a better terminal emulator
-
-    # Fonts
-    cask "font-fira-code"
-    cask "font-jetbrains-mono"
-    cask "font-cascadia-mono"
-    cask "font-symbols-only-nerd-font"
-    cask "font-recursive-code"
-elsif OS.linux?
-    brew "xclip" # access to clipboard (similar to pbcopy/pbpaste)
-end
+# Linux clipboard helper (was inside the removed elsif OS.linux? block)
+brew "xclip" # access to clipboard (similar to pbcopy/pbpaste)
 
 tap "homebrew/bundle"
-tap "homebrew/core"
+# tap "homebrew/core" removed — homebrew/core is auto-tapped since ~2021
 
 # packages
 brew "fd" # find alternative
@@ -50,7 +35,11 @@ brew "node"
 brew "repo"
 brew "htop"
 brew "gemini-cli"
-brew "copilot-cli"
+# copilot-cli removed — the formula no longer exists in homebrew-core (the
+# "copilot" formula there is Amazon ECS Copilot, not GitHub's). GitHub's
+# Copilot CLI is now a cask: install manually with
+# `brew install --cask copilot-cli` if needed. Existing Caskroom installs
+# are preserved (brew bundle does not uninstall entries missing from the Brewfile).
 brew "git-delta"
 brew "atuin" # magical shell history (replaces fzf Ctrl-R history search)
 brew "yazi" # terminal file manager (image preview, async I/O); launch with `y` / `yc`


### PR DESCRIPTION
## What

Makes the `Brewfile` linux-only to match the target environment in `AGENTS.md` (WSL2 Ubuntu). Fixes two errors/warnings from `./install.sh homebrew`:

1. **`Tapping homebrew/core is no longer typically necessary`** — `homebrew/core` is auto-tapped since ~2021. Removed `tap "homebrew/core"`.
2. **`Warning: 'copilot-cli' formula is unreadable: No available formula with the name "copilot-cli"`** — the `copilot-cli` formula was removed from homebrew-core (the `copilot` formula there is now Amazon ECS Copilot, not GitHub's). GitHub's Copilot CLI moved to a cask. Removed `brew "copilot-cli"` from the Brewfile.

## What was removed

| Entry | Reason |
| --- | --- |
| `tap "homebrew/cask"` | Linux-only target; casks unused |
| `tap "homebrew/cask-fonts"` | WSL2 uses Windows host fonts |
| `tap "koekeishiya/formulae"` | For `skhd`/`yabai` (mac tiling WM) |
| `brew "noti"` | macOS notification CLI |
| `brew "trash"` | Moves files to macOS Trash |
| `cask "imageoptim"` | mac-only image optimizer |
| `cask "1password/tap/1password-cli"` | Install via WSL host if needed |
| `cask "wezterm"` | wezterm runs on Windows host for WSL2; linuxbrew cask unused |
| `cask "font-fira-code"` | WSL2 uses Windows host fonts |
| `cask "font-jetbrains-mono"` | WSL2 uses Windows host fonts |
| `cask "font-cascadia-mono"` | WSL2 uses Windows host fonts |
| `cask "font-symbols-only-nerd-font"` | WSL2 uses Windows host fonts |
| `cask "font-recursive-code"` | WSL2 uses Windows host fonts |
| `tap "homebrew/core"` | Auto-tapped since ~2021 (caused the warning) |
| `brew "copilot-cli"` | Formula removed from homebrew-core; now a cask |

## What was kept

- `tap "homebrew/bundle"` — redundant (`brew bundle` is built-in now) but harmless; ensures availability on fresh systems.
- All 24 linux-shared formulae (`fd`, `fzf`, `git`, `lazygit`, `neovim`, `tmux`, `yazi`-prereq, `atuin`, etc.).
- `brew "xclip"` — promoted from inside the removed `elsif OS.linux?` block to the top level.

## Verification

- `ruby -c Brewfile` → `Syntax OK`
- `brew bundle check --file=Brewfile` → `The Brewfile's dependencies are satisfied.` (exit 0, no warnings)
- `git diff --stat` → only `Brewfile` changed (14 insertions, 25 deletions)
- Cross-checked: no references to removed packages (`noti`, `trash`, `imageoptim`, `koekeishiya`, `1password`, font casks) exist in the user's config files (only in gitignored oh-my-zsh vendored plugins)
- `config/wezterm/wezterm.lua` uses `"JetBrainsMono Nerd Font"` — resolved by the Windows-host wezterm, not linuxbrew fonts. Font cask removal is safe.

## About `copilot-cli`

Your existing install at `/home/linuxbrew/.linuxbrew/Caskroom/copilot-cli/1.0.57` is **preserved** — `brew bundle` (without `--cleanup`) does not uninstall entries missing from the Brewfile. To install on a fresh machine:

```bash
brew install --cask copilot-cli
```

## Not touched in this PR

- `Brewfile.lock.json` — regenerate post-merge:
  ```bash
  ./install.sh homebrew
  git add Brewfile.lock.json
  git commit -m "chore(brew): regenerate lockfile for linux-only cleanup"
  git push
  ```
- `config/wezterm/` — still used by the Windows-host wezterm (symlinked to `~/.config/wezterm/`)
- `README.md` / `AGENTS.md` — already document the linux-only target

## Relationship to PR #17 (feat/yazi)

This PR branches off `origin/main` (which does not yet have the yazi/chafa lines). PR #17 appends `yazi` + `chafa` to the Brewfile tail. GitHub will flag a merge conflict between the two PRs. **Resolution**: after #17 merges, rebase this branch onto the updated `main` — the conflict is trivial (keep the mac-block removal from this PR, keep the yazi/chafa tail from #17). I will handle the rebase if needed.

## Rule of thumb

This Brewfile finally matches reality: the target environment has been WSL2-only since the atuin migration (per `AGENTS.md`), but the mac entries lingered from the upstream `nicknisi/dotfiles` fork. macOS users who fork this repo can restore the mac block from git history.