### PR TITLE
fix(zsh): add linuxbrew functions to fpath and fix FZF_BASE path

### DIFF
--- a/zsh/zshenv.symlink
+++ b/zsh/zshenv.symlink
@@ -16,11 +16,14 @@ export RIPGREP_CONFIG_PATH="$HOME/.config/ripgrep/config"
 
 fpath=(
     $DOTFILES/zsh/functions
+    ${HOMEBREW_PREFIX:+$HOMEBREW_PREFIX/share/zsh/functions}
+    ${HOMEBREW_PREFIX:+$HOMEBREW_PREFIX/share/zsh/site-functions}
     /usr/local/share/zsh/site-functions
     $fpath
 )
 
 typeset -aU path
+typeset -aU fpath
 
 export EDITOR='nvim'
 export GIT_EDITOR='nvim'
@@ -28,5 +31,5 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export COLORTERM=truecolor
 
 if [[ -n "$HOMEBREW_PREFIX" ]]; then
-  export FZF_BASE="$HOMEBREW_PREFIX/bin"
+  export FZF_BASE="$HOMEBREW_PREFIX/opt/fzf"
 fi


### PR DESCRIPTION
## What

Fixes a cascade of zsh startup errors after `brew bundle` upgraded zsh 5.9 → 5.9.1:

```
compinit: function definition file not found
add-zsh-hook: function definition file not found
is-at-least: function definition file not found
colors: function definition file not found
vcs_info: function definition file not found
[oh-my-zsh] fzf plugin: Cannot find fzf installation directory.
[ERROR]: gitstatus failed to initialize.
```

## Root cause

**`brew shellenv`** (called by `zprofile.symlink:13`) exports `FPATH` into the environment with a **version-specific** Cellar path:

```bash
# /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/shellenv.sh:81-84
if [[ "${HOMEBREW_SHELL_NAME}" == "zsh" ]]; then
    echo "fpath[1,0]=\"${HOMEBREW_PREFIX}/share/zsh/site-functions\";"
    echo "export FPATH;"    # ← exports FPATH with current fpath (incl. Cellar/zsh/5.9/...)
fi
```

The chain:
1. `zprofile.symlink` evals `brew shellenv` → `FPATH` is exported with `Cellar/zsh/5.9/share/zsh/functions`
2. `tmux` server starts and **captures the exported `FPATH`** in its environment
3. `brew bundle` upgrades zsh 5.9 → 5.9.1 → `Cellar/zsh/5.9/` directory is **deleted**
4. Every new tmux pane inherits the **stale `FPATH`** from the tmux server → zsh cannot find `compinit`, `add-zsh-hook`, `is-at-least`, `colors`, `vcs_info`

This cascaded to:
- **oh-my-zsh**: `compinit` and `bashcompinit` fail → no completions
- **fzf plugin**: `fzf_setup_using_fzf` calls `autoload -Uz is-at-least` → fails (fpath issue) → falls back to `fzf_setup_using_base_dir` → fails because `FZF_BASE=$HOMEBREW_PREFIX/bin` has no `shell/` subdir
- **powerlevel10k**: `add-zsh-hook` and `vcs_info` fail → gitstatus fails to initialize

## Fix (3 changes in `zsh/zshenv.symlink`)

### 1. Add stable linuxbrew functions path to fpath
```zsh
fpath=(
    $DOTFILES/zsh/functions
    ${HOMEBREW_PREFIX:+$HOMEBREW_PREFIX/share/zsh/functions}
    ${HOMEBREW_PREFIX:+$HOMEBREW_PREFIX/share/zsh/site-functions}
    /usr/local/share/zsh/site-functions
    $fpath
)
```
`$HOMEBREW_PREFIX/share/zsh/functions` is a **stable, non-version-specific** path that always contains the current zsh version's function files. This fixes all "function definition file not found" errors regardless of what stale paths are inherited.

### 2. Fix `FZF_BASE`
```zsh
# was:  export FZF_BASE="$HOMEBREW_PREFIX/bin"
export FZF_BASE="$HOMEBREW_PREFIX/opt/fzf"
```
`$HOMEBREW_PREFIX/opt/fzf` has the `shell/` subdir (`key-bindings.zsh`, `completion.zsh`) that the oh-my-zsh fzf plugin expects. The primary fzf setup path (`fzf --zsh`) will also work once fpath is fixed, but this fixes the fallback too.

### 3. Deduplicate fpath
```zsh
typeset -aU fpath
```
The inherited environment has fpath entries duplicated 2-3×. `typeset -aU` keeps only the first occurrence.

## Verification

- `zsh -n zsh/zenv.symlink` → syntax OK
- Simulated stale `FPATH` (with non-existent `Cellar/zsh/5.9/` path) + sourced fixed zshenv:
  ```
  compinit: OK
  add-zsh-hook: OK
  is-at-least: OK
  colors: OK
  vcs_info: OK
  ```
- `FZF_BASE=$HOMEBREW_PREFIX/opt/fzf` → `shell/key-bindings.zsh` and `shell/completion.zsh` confirmed present

## Post-merge action

The stale `FPATH` persists in the running tmux server. After merging and pulling:

```bash
tmux kill-server     # clears stale FPATH from tmux server environment
# Open a new terminal — fresh zsh login shell gets clean environment
```

Existing tmux sessions will be lost. Alternatively, open a new WezTerm window outside tmux to verify, then restart tmux at your convenience.

## Why not un-export FPATH?

`brew shellenv` expects `FPATH` to be exported (it appends to it via `fpath[1,0]=...`). Un-exporting it would break brew's expectation. The stale path is harmless — zsh silently ignores nonexistent directories for autoload lookups. Adding the stable path is the minimal, non-invasive fix.