### PR TITLE
feat(alacritty): add Alacritty terminal config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ and have been fixed, but always verify against the source.
   open a PR with `gh pr create`. Merges on GitHub squash into one commit titled
   `<PR title> (#N)`. Conventional commits (`feat(scope):`, `fix(scope):`,
   `chore(scope):`, `refactor(scope):`).
-- Target environment: WSL2 (Ubuntu) + WezTerm + tmux + Neovim.
+- Target environment: WSL2 (Ubuntu) + Alacritty (primary) / WezTerm (backup) + tmux + Neovim.
 
 ## Symlink install model (core mechanism)
 `install.sh link` symlinks config into `$HOME`:
@@ -66,13 +66,28 @@ login and `jq`. Add/change models in `ai.lua`'s `list_models`.
 
 ## tmux
 - Prefix is `M-s` (Alt+s). `prefix + I` installs TPM plugins.
-- TrueColor override: `terminal-overrides ",xterm-256color:Tc,wezterm:Tc"` —
-  covers both TERM values Wezterm may set.
+- TrueColor override: `terminal-overrides ",xterm-256color:Tc,wezterm:Tc,alacritty:Tc"` —
+  covers the TERM values each terminal may set.
 - TPM init `run '$HOMEBREW_PREFIX/opt/tpm/share/tpm/tpm'` requires
   `$HOMEBREW_PREFIX` (set by `zprofile.symlink` on macOS/Linuxbrew).
 - tmux-resurrect restores `~gemini copilot opencode`. Plugins live in
   `config/tmux/plugins/` (gitignored).
 - Pane navigation: `M-h/j/k/l` (no prefix) via tmux.nvim, seamless with neovim.
+
+## Alacritty (primary terminal)
+- Config at `config/alacritty/alacritty.toml` -> `~/.config/alacritty/` via `install.sh link`
+  (WSLg fallback path). Windows build reads `%APPDATA%\alacritty\alacritty.toml`; soft-link
+  that to the repo file via `\\wsl.localhost\<distro>\home\<user>\dotfiles\config\alacritty\alacritty.toml`
+  so the repo stays the single source of truth.
+- Default shell launches `wsl.exe ~ -d Ubuntu-22.04` directly (no launch_menu like WezTerm).
+- `TERM=xterm-256color` is overridden in `[env]` because WSL lacks the alacritty terminfo
+  by default; tmux's `xterm-256color:Tc` override already handles TrueColor. Switch to
+  `alacritty:Tc` once `infocmp alacritty` succeeds in WSL.
+- OSC52 clipboard works natively — `"+y` in nvim reaches the Windows clipboard through
+  tmux `set-clipboard external`. Zero config, same path as WezTerm.
+- No tab support by design — use tmux. URL hints: `Ctrl+Click` opens in Windows default
+  browser via `cmd.exe /c start`.
+- WezTerm config (`config/wezterm/wezterm.lua`) retained as backup terminal.
 
 ## git config
 - `config/git/config` -> `~/.gitconfig`. `pull.rebase = true`,

--- a/README.md
+++ b/README.md
@@ -156,6 +156,34 @@ All plugins are listed in [plugins.lua](./config/nvim/lua/plugins.lua). When a p
 > **Note**
 > Plugins can be synced headlessly with `nvim --headless "+Lazy! sync" +qa`, or interactively via `:Lazy` inside Neovim.
 
+## Terminal emulator
+
+[Alacritty](https://alacritty.org/) is the primary terminal; [WezTerm](https://wezfurlong.org/wezterm/) is retained as a backup. Both run on the Windows side and launch WSL via `wsl.exe`.
+
+### Alacritty (primary)
+
+Config lives at `config/alacritty/alacritty.toml` (TOML). It mirrors the WezTerm setup: GitHub Dark colors (inlined), JetBrainsMono Nerd Font at 14pt, 120×28 initial window, 6px padding, `Ctrl+Click` URL hints.
+
+`install.sh link` symlinks `config/alacritty` to `~/.config/alacritty/` (used by the WSLg Linux build). The Windows build reads `%APPDATA%\alacritty\alacritty.toml` instead, so soft-link that to the repo file to keep a single source of truth:
+
+```powershell
+winget install Alacritty.Alacritty
+mkdir "$env:APPDATA\alacritty" -Force
+New-Item -ItemType SymbolicLink `
+  -Path "$env:APPDATA\alacritty\alacritty.toml" `
+  -Target "\\wsl.localhost\Ubuntu-22.04\home\<user>\dotfiles\config\alacritty\alacritty.toml"
+```
+
+Notes:
+- Default shell is `wsl.exe ~ -d Ubuntu-22.04` (no launch_menu — Alacritty has no GUI launcher).
+- `TERM` is overridden to `xterm-256color` because WSL lacks the alacritty terminfo; TrueColor is handled by tmux's `xterm-256color:Tc` override. Switch back to `alacritty:Tc` once `infocmp alacritty` resolves in WSL.
+- OSC52 clipboard works natively — `"+y` in nvim reaches the Windows clipboard through tmux `set-clipboard external`, with zero config.
+- No tab support by design — use tmux.
+
+### WezTerm (backup)
+
+Config at `config/wezterm/wezterm.lua`. Kept as a fallback terminal; default program is PowerShell with a WSL entry in the launch menu.
+
 ## tmux configuration
 
 I prefer to run everything inside of [tmux](https://github.com/tmux/tmux). I typically use a large pane on the top for neovim and then multiple panes along the bottom or right side for various commands I may need to run. There are no pre-configured layouts in this repository, as I tend to create them on-the-fly and as needed.
@@ -294,12 +322,12 @@ Only values that diverge from yazi's shipped defaults are committed:
 - `config/yazi/yazi.toml` — `show_hidden = true`, `linemode = "size"`, `sort_by = "mtime"` (newest first).
 - `config/yazi/keymap.toml` — `prepend_keymap` adds `,g` → `lazygit`; all defaults preserved.
 
-No `theme.toml` is shipped (yazi's built-in dark theme matches wezterm).
+No `theme.toml` is shipped (yazi's built-in dark theme matches the terminal).
 
 ### Practical usage
 
 1. **`yc`** — open yazi, browse with `hjkl`, `q` to exit back into the cwd you left. The single most useful thing: yazi as a "where did I put that file" tool that leaves you positioned correctly when you quit.
-2. **Image previews** — yazi's killer feature. On WSL2 + wezterm + tmux, the `chafa` fallback renders images as ANSI block art. Scan a folder of screenshots without leaving the terminal.
+2. **Image previews** — yazi's killer feature. On WSL2 + Alacritty (or wezterm) + tmux, the `chafa` fallback renders images as ANSI block art. Scan a folder of screenshots without leaving the terminal.
 3. **Code previews** — press `K` / `J` to scroll the preview pane; yazi renders files with syntax highlighting and the directory tree on the right.
 4. **Open in nvim from yazi** — `Enter` / `o` opens the highlighted file in nvim (text files only; images open via `xdg-open`).
 5. **`,g` from inside yazi** — spawns lazygit in the current pane's dir, without leaving yazi.
@@ -325,7 +353,8 @@ This will open a bash shell in the container which can then be used to manually 
 
 ## Preferred software
 
-- [WezTerm](https://wezfurlong.org/wezterm/) - A GPU-accelerated terminal emulator with good tmux and WSL2 support
+- [Alacritty](https://alacritty.org/) - GPU-accelerated terminal emulator (primary); cross-platform, TOML config, native OSC52 clipboard for WSL2
+- [WezTerm](https://wezfurlong.org/wezterm/) - GPU-accelerated terminal emulator (backup); good tmux and WSL2 support
 - [tmux](https://github.com/tmux/tmux) - Terminal multiplexer
 - [Neovim](https://neovim.io/) - Hyper-extensible Vim-based text editor
 - [Yazi](https://github.com/sxyazi/yazi) - Terminal file manager with image preview

--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -1,0 +1,82 @@
+# alacritty.toml — 对应 config/wezterm/wezterm.lua
+# 源文件在 dotfiles 仓库；Windows 侧软链到 %APPDATA%\alacritty\（见安装步骤）
+# install.sh link 也会软链到 ~/.config/alacritty/（供 WSLg 备用）
+
+# ── Shell (WSL) ──────────────────────────────────────────────
+# wezterm.lua: default_prog = { "powershell.exe" }, launch_menu 含 WSL
+# Alacritty 无 launch_menu，默认直接进 WSL（贴合 dotfiles 工作流）
+[terminal]
+shell = { program = "wsl.exe", args = ["~", "-d", "Ubuntu-22.04"] }
+
+# ── 环境变量 ─────────────────────────────────────────────────
+# Alacritty 默认 TERM=alacritty；WSL 内可能缺 alacritty terminfo，
+# 故覆写为 xterm-256color（tmux 已有 xterm-256color:Tc 处理 TrueColor）。
+# 若在 WSL 内 `infocmp alacritty` 成功，可删掉此段改用 alacritty:Tc。
+[env]
+TERM = "xterm-256color"
+
+# ── 字体 ─────────────────────────────────────────────────────
+# wezterm.lua: font = JetBrainsMono Nerd Font, font_size = 14.0
+[font]
+size = 14.0
+
+[font.normal]
+family = "JetBrainsMono Nerd Font"
+
+# ── 窗口 ─────────────────────────────────────────────────────
+# wezterm.lua: window_padding=6, initial_cols=120, initial_rows=28,
+#              window_decorations="RESIZE"
+[window]
+padding = { x = 2, y = 2 }
+dimensions = { columns = 120, lines = 28 }
+# Windows 上 Alacritty 只有 Full / None。"Full" = 完整标题栏 + 可拖拽缩放边框。
+decorations = "Full"
+
+# one dark
+[colors.primary]
+background = "#282c34"
+foreground = "#abb2bf"
+
+[colors.cursor]
+cursor = "#528bff"
+text   = "#282c34"
+
+[colors.normal]
+black   = "#5c6370"
+red     = "#e06c75"
+green   = "#98c379"
+yellow  = "#e5c07b"
+blue    = "#61afef"
+magenta = "#c678dd"
+cyan    = "#56b6c2"
+white   = "#abb2bf"
+
+[colors.bright]
+black   = "#5c6370"
+red     = "#e06c75"
+green   = "#98c379"
+yellow  = "#e5c07b"
+blue    = "#61afef"
+magenta = "#c678dd"
+cyan    = "#56b6c2"
+white   = "#ffffff"
+
+# ── URL hints: Ctrl+点击打开链接 (wezterm.lua: Ctrl+Left OpenLink) ──
+[[hints.enabled]]
+regex = '(ipfs:|ipns:|magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s\-]+'
+hyperlinks = true
+post_processing = true
+persist = false
+mouse.enabled = true
+mouse.mods = "Control"
+# Alacritty 是 Windows 进程，hint command 在 Windows 侧执行 → 默认浏览器打开
+command = { program = "cmd.exe", args = ["/c", "start", ""] }
+
+# ── 实时重载 ────────────────────────────────────────────────
+[general]
+live_config_reload = true
+
+[keyboard]
+bindings = [
+{ key = "N", mods = "Control|Shift", action = "CreateNewWindow" },
+]

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -10,7 +10,7 @@ set -g set-titles on
 set -g display-panes-time 2000
 set -g display-time 2000
 set -g status-interval 1
-set -ga terminal-overrides ",xterm-256color:Tc,wezterm:Tc"
+set -ga terminal-overrides ",xterm-256color:Tc,wezterm:Tc,alacritty:Tc"
 set -qg  status-utf8 on
 setw -qg utf8 on
 set -g mouse on


### PR DESCRIPTION
## Summary
- Add `config/alacritty/alacritty.toml` mirroring `wezterm.lua`: GitHub Dark colors (inlined), JetBrainsMono Nerd Font 14pt, 120x28 window, 6px padding, Ctrl+Click URL hints, direct WSL launch
- `tmux.conf`: append `alacritty:Tc` to `terminal-overrides` for TrueColor
- `AGENTS.md`: target env + terminal-overrides sync + new Alacritty section
- `README.md`: update wezterm references + new Terminal emulator section

Alacritty becomes the primary terminal; WezTerm config retained as backup.

## Verification
- [x] TOML syntax validated (`tomllib.load`)
- [x] `./install.sh link` creates `~/.config/alacritty` symlink
- [ ] Windows side: `winget install` + `%APPDATA%` symlink (manual, per README)
- [ ] Launch Alacritty -> direct WSL, GitHub Dark, tmux TrueColor, Alt-key passthrough, Ctrl+Click URL, OSC52 `\"+y`