### PR TITLE
refactor(alacritty): use TERM=alacritty after verifying terminfo

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -9,11 +9,11 @@
 shell = { program = "wsl.exe", args = ["~", "-d", "Ubuntu-22.04"] }
 
 # ── 环境变量 ─────────────────────────────────────────────────
-# Alacritty 默认 TERM=alacritty；WSL 内可能缺 alacritty terminfo，
-# 故覆写为 xterm-256color（tmux 已有 xterm-256color:Tc 处理 TrueColor）。
-# 若在 WSL 内 `infocmp alacritty` 成功，可删掉此段改用 alacritty:Tc。
+# TERM=alacritty 经验证可用（infocmp alacritty 成功，Linuxbrew ncurses 6.6）。
+# TrueColor 由 COLORTERM=truecolor (zshenv) + tmux alacritty:Tc override 双重保证，
+# 不依赖 terminfo 内建的 Tc（alacritty 条目仅含 initc，256 色）。
 [env]
-TERM = "xterm-256color"
+TERM = "alacritty"
 
 # ── 字体 ─────────────────────────────────────────────────────
 # wezterm.lua: font = JetBrainsMono Nerd Font, font_size = 14.0


### PR DESCRIPTION
## Summary
Switch `TERM` from `xterm-256color` to `alacritty` after verifying the terminfo is available in WSL.

## Verification
- `infocmp alacritty` succeeds (Linuxbrew ncurses 6.6, `/home/linuxbrew/.linuxbrew/.../terminfo/a/alacritty`)
- `TERM=alacritty tput colors` returns 256, no "unknown terminal" error
- Key caps (arrows/Insert/Delete/Home/End) match `xterm-256color` exactly
- `alacritty-direct` variant also exists (`colors#0x1000000` = TrueColor)

## Why it's safe
TrueColor does not depend on terminfo's `Tc` cap (`alacritty` entry only has `initc`, 256-color). Two independent guarantees:
1. `zshenv.symlink:31` sets `COLORTERM=truecolor` → modern programs (nvim, etc.) enable 24-bit color from this
2. `tmux.conf:13` has `alacritty:Tc` in `terminal-overrides` → tmux-internal programs get TrueColor

## Benefit
Terminal identification is now accurate; programs can key off the `alacritty` name to enable Alacritty-specific behavior. Also tightens the comment to reflect the actual mechanism (previous comment ambiguously referenced `alacritty:Tc` as if it were a TERM value).