### PR TITLE
feat(nvim): replace cmake-language-server with neocmakelsp

### DIFF
--- a/config/nvim/lua/plugins/astrolsp.lua
+++ b/config/nvim/lua/plugins/astrolsp.lua
@@ -106,7 +106,26 @@ return {
                 },
             },
             bashls = {},
-            cmake = {},
+            neocmake = {
+                single_file_support = true,
+                capabilities = {
+                    textDocument = {
+                        completion = { completionItem = { snippetSupport = true } },
+                    },
+                    workspace = {
+                        didChangeWatchedFiles = {
+                            dynamicRegistration = true,
+                            relative_pattern_support = true,
+                        },
+                    },
+                },
+                init_options = {
+                    format = { enable = false },
+                    lint = { enable = true },
+                    scan_cmake_in_package = true,
+                    semantic_token = false,
+                },
+            },
             verible = {
                 cmd = { "verible-verilog-ls", "--rules=-no-tabs" },
                 root_markers = { "verible.filelist" },

--- a/config/nvim/lua/plugins/mason.lua
+++ b/config/nvim/lua/plugins/mason.lua
@@ -16,7 +16,7 @@ return {
             ensure_installed = {
                 -- install language servers
                 "clangd",
-                "cmake-language-server",
+                "neocmakelsp",
                 "bash-language-server",
                 "verible",
 


### PR DESCRIPTION
- neocmakelsp provides richer CMake support including linting, package
  scanning, and configurable formatting
- previous cmake-language-server entry had no configuration at all
