### PR TITLE
feat(codegraph): integrate code-knowledge MCP for opencode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ config/opencode/antigravity-accounts.json.*.tmp
 config/opencode/antigravity-accounts.json.lock
 config/opencode/antigravity-signature-cache.json
 config/opencode/antigravity-logs/
+
+# CodeGraph per-project indexes — built by `codegraph init` in each code
+# project, never committed here. Safety net in case init is run in this repo.
+.codegraph/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ and have been fixed, but always verify against the source.
   - type: `feat fix docs style refactor perf test build ci chore revert`.
     Breaking change: `type(scope)!:` or `BREAKING CHANGE:` footer.
   - scope: tool/module name (`zsh nvim tmux git alacritty wezterm brew install
-    agents yazi ai`); multiple scopes comma-separated, e.g. `feat(zsh,config):`.
+    agents yazi ai codegraph`); multiple scopes comma-separated, e.g. `feat(zsh,config):`.
   - body: `feat/fix/refactor/perf` recommended — write "why" not "what" (the
     diff shows what), use `-` bullets, ≤72 chars/line, blank line after subject.
     `chore/style/revert` and simple single-file changes may omit.
@@ -100,6 +100,30 @@ file is not managed); `package.json` is regenerated from `opencode.json`'s
 defined in `config/opencode/commands/commit.md` headlessly. To add a new
 custom command, drop `config/opencode/commands/<name>.md` (frontmatter +
 template, per https://opencode.ai/docs/commands).
+
+## CodeGraph (global code-knowledge MCP)
+CodeGraph is a pre-indexed, 100% local knowledge graph of symbols/calls/deps
+for AI coding agents (opencode, Claude Code, Cursor, etc.). Exposes one MCP
+tool — `codegraph_explore` — that returns surgical context + call paths in a
+single call instead of a grep/Read crawl. 20+ languages, auto-syncs on file
+changes. Repo: https://github.com/colbymchenry/codegraph
+- **CLI install**: `./install.sh codegraph` (idempotent). Not on Homebrew; the
+  official installer bundles its own Node runtime and places `codegraph` on a
+  user bin already on PATH (`~/.local/bin` via `zsh/zshenv.symlink`). Also run
+  by `./install.sh all`. No Node dependency on the brew-managed `node`.
+- **opencode MCP wiring**: `config/opencode/opencode.json` has a `codegraph`
+  local MCP server (`["codegraph", "serve", "--mcp"]`, `enabled: true`).
+  Configured manually — **do not** run `codegraph install` (it would rewrite
+  agent configs and AGENTS.md out of band).
+- **Per-project indexing is manual and NOT in this repo**: run `codegraph init`
+  in each *code* project to build its `.codegraph/` graph. This dotfiles repo
+  only does the *global* wiring (CLI + MCP config). Projects without a
+  `.codegraph/` index degrade gracefully — CodeGraph tells the agent to use
+  built-in tools.
+- `.codegraph/` is gitignored at repo root as a safety net.
+- Scope is **opencode only** here — this repo does not manage `~/.claude.json`
+  or other agents' configs, so CodeGraph's Claude Code/Cursor wiring is out of
+  scope for this dotfiles.
 
 ## tmux
 - Prefix is `M-s` (Alt+s). `prefix + I` installs TPM plugins.

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -5,6 +5,11 @@
       "type": "remote",
       "url": "https://mcp.context7.com/mcp",
       "enabled": true
+    },
+    "codegraph": {
+      "type": "local",
+      "command": ["codegraph", "serve", "--mcp"],
+      "enabled": true
     }
   },
   "plugin": ["@franlol/opencode-md-table-formatter@latest"],

--- a/install.sh
+++ b/install.sh
@@ -161,6 +161,23 @@ setup_shell() {
     fi
 }
 
+# CodeGraph — pre-indexed code knowledge graph for AI agents (opencode, etc.).
+# Not on Homebrew; the official installer bundles its own Node runtime and
+# places `codegraph` on a user-level bin already on PATH (~/.local/bin, see
+# zshenv.symlink). Idempotent: skips if `codegraph` is already on PATH.
+# Per-project indexing (`codegraph init`) is NOT done here — only the global
+# CLI. The opencode MCP wiring lives in config/opencode/opencode.json.
+setup_codegraph() {
+    title "Setting up CodeGraph"
+
+    if command -v codegraph >/dev/null 2>&1; then
+        info "codegraph already installed ($(codegraph --version 2>/dev/null || echo present)), skipping."
+    else
+        info "Installing CodeGraph via official installer (bundles its own Node runtime)."
+        curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh
+    fi
+}
+
 setup_ohmyzsh() {
     title "Configuring ohmyzsh"
 
@@ -204,15 +221,19 @@ case "$1" in
     shell)
         setup_shell
         ;;
+    codegraph)
+        setup_codegraph
+        ;;
     all)
         setup_symlinks
         setup_homebrew
         setup_git
         setup_ohmyzsh
         setup_shell
+        setup_codegraph
         ;;
     *)
-        echo -e $"\nUsage: $(basename "$0") {backup|link|git|homebrew|ohmyzsh|shell|all}\n"
+        echo -e $"\nUsage: $(basename "$0") {backup|link|git|homebrew|ohmyzsh|shell|codegraph|all}\n"
         exit 1
         ;;
 esac


### PR DESCRIPTION
CodeGraph exposes a pre-indexed, 100% local symbol/call graph so AI agents fetch surgical context in one tool call instead of a grep/Read crawl — fewer round-trips and faster answers on every codebase. Wire only the global pieces into the dotfiles; per-project indexing stays a manual `codegraph init` in each code repo.

- **install.sh**: idempotent `setup_codegraph` via the official curl installer (bundles its own Node runtime, lands on `~/.local/bin` which `zshenv.symlink` already puts on PATH); added to `all` and exposed as a `codegraph` subcommand.
- **opencode.json**: `codegraph` local MCP server (`serve --mcp`), `enabled: true`.
- **AGENTS.md**: document the global wiring, per-project `codegraph init`, graceful degradation without an index, and the opencode-only scope boundary (this repo doesn't manage `~/.claude.json`). Add `codegraph` to the commit-scope list.
- **.gitignore**: `.codegraph/` safety net in case init is run in this repo.

### Scope boundary
This wires CodeGraph for **opencode only** — Claude Code/Cursor/etc. configs are out of scope for this dotfiles repo. CLI install is global and agent-agnostic; the MCP server config is opencode-specific.

### Post-merge steps (manual)
1. `./install.sh codegraph` (or `all`) — installs the CLI to `~/.local/bin`.
2. Restart opencode so the MCP server loads.
3. In each **code project** (not this repo): `codegraph init` to build its `.codegraph/` graph.