### PR TITLE
feat(opencode): enable websearch, lsp, permissions and global rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,15 +78,27 @@ login and `jq`. Add/change models in `ai.lua`'s `list_models`.
 
 ## OpenCode (opencode CLI config)
 `config/opencode/` -> `~/.config/opencode/` via `install.sh link` (same
-`config/<tool>` convention as atuin/yazi/alacritty). Two managed files:
+`config/<tool>` convention as atuin/yazi/alacritty). Three managed files:
 - `opencode.json` — providers (`google` antigravity models), MCP servers
-  (`context7`), formatters (`clang-format`), plugins
-  (`@franlol/opencode-md-table-formatter`). **No secrets here** — the former
-  `bailian-coding-plan-test` provider with a hardcoded `apiKey` was removed;
-  provider credentials live in `~/.local/share/opencode/auth.json` (never in
-  repo).
+  (`context7` remote, `codegraph` local), `lsp: true` (diagnostic feedback),
+  `permission` (safety gates: `rm`/force-push ask, rest allow), formatters
+  (`clang-format`), plugins (`@franlol/opencode-md-table-formatter`). **No
+  secrets here** — the former `bailian-coding-plan-test` provider with a
+  hardcoded `apiKey` was removed; provider credentials live in
+  `~/.local/share/opencode/auth.json` (never in repo).
+- `AGENTS.md` — **global rules**, symlinked to
+  `~/.config/opencode/AGENTS.md`, applied to every opencode session. Holds the
+  web-fetching fallback strategy (context7 / Jina Reader / gh) and MCP usage
+  priority rules (context7 for lib docs, codegraph for code structure). A
+  project's own `AGENTS.md` layers on top and takes precedence.
 - `commands/commit.md` — the `/commit` custom command (Conventional Commits
   message generator, reads staged diff + recent history + AGENTS.md).
+
+Built-in `websearch` (Exa, free, no API key) is enabled globally via
+`OPENCODE_ENABLE_EXA=1` in `zsh/zshenv.symlink` — required when not on the
+opencode provider. LSP is on (`lsp: true`); lua-ls and clangd auto-install,
+Python needs a manual `npm install -g pyright`. Disable a single server
+per-project with `lsp.<name>.disabled: true`.
 
 Runtime files opencode regenerates inside the symlinked dir are gitignored at
 repo root: `node_modules/`, `package.json`, `package-lock.json`, `bun.lock`,

--- a/config/opencode/AGENTS.md
+++ b/config/opencode/AGENTS.md
@@ -1,0 +1,43 @@
+# Global opencode rules
+
+Applies to every opencode session across all projects. A project's own
+`AGENTS.md` layers on top of these and takes precedence. This file lives at
+`config/opencode/AGENTS.md` and is symlinked to `~/.config/opencode/AGENTS.md`
+by `install.sh link`, so opencode auto-loads it as global rules.
+
+## Web content fetching strategy
+
+`webfetch` does a plain HTTP GET + HTML-to-markdown conversion — it does NOT
+execute JavaScript. It returns empty or near-empty content for:
+- SPA docs sites (Astro/Docusaurus/Next.js/VuePress) whose first paint is a
+  bare `<div id="root">` + JS bundle
+- JS-based redirects (`location.href`)
+- bot-detection / auth-walled / paywalled pages
+
+Use these fallbacks before giving up on a URL:
+
+1. **Library/framework docs -> use the `context7` MCP** (not `webfetch`). It
+   returns pre-extracted docs and bypasses SPA rendering entirely. Prefer it
+   for any named library or framework.
+2. **Generic pages -> Jina Reader proxy.** Retry as
+   `webfetch https://r.jina.ai/<original-url>`. Jina renders server-side and
+   returns clean markdown. Free, no API key.
+3. **GitHub content -> use `gh` CLI or raw URLs.** Fetch
+   `raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>` for source, or
+   run `gh api ...` for API data. Do not `webfetch` github.com pages (heavy
+   SPA).
+4. **Discovery vs retrieval.** Use `websearch` (Exa) to find relevant URLs,
+   then `webfetch` to read a specific one. `websearch` is enabled globally via
+   `OPENCODE_ENABLE_EXA=1` in `zsh/zshenv.symlink`.
+
+## MCP usage rules
+
+MCP tools are available automatically; these rules set priority so the agent
+reaches for the right tool instead of defaulting to a grep/Read crawl.
+
+- **context7**: when the question involves a named library or framework's
+  docs/API, use `context7` first rather than `webfetch`-ing the official site.
+- **codegraph**: in a project that has a `.codegraph/` index, answer code
+  structure / call-path / impact-radius questions with `codegraph_explore`
+  instead of grepping file-by-file. If no `.codegraph/` index exists,
+  CodeGraph will say so — fall back to built-in `grep`/`read`/`glob`.

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -12,6 +12,16 @@
       "enabled": true
     }
   },
+  "lsp": true,
+  "permission": {
+    "bash": {
+      "*": "allow",
+      "rm *": "ask",
+      "git push --force*": "ask",
+      "git push -f *": "ask"
+    },
+    "codegraph_*": "allow"
+  },
   "plugin": ["@franlol/opencode-md-table-formatter@latest"],
   "formatter": {
     "clang-format": {

--- a/zsh/zshenv.symlink
+++ b/zsh/zshenv.symlink
@@ -29,6 +29,9 @@ export EDITOR='nvim'
 export GIT_EDITOR='nvim'
 export HOMEBREW_NO_AUTO_UPDATE=1
 export COLORTERM=truecolor
+# Enable opencode's built-in websearch (Exa, free, no API key). Required when
+# not using the opencode provider; without it only webfetch is available.
+export OPENCODE_ENABLE_EXA=1
 
 if [[ -n "$HOMEBREW_PREFIX" ]]; then
   export FZF_BASE="$HOMEBREW_PREFIX/opt/fzf"


### PR DESCRIPTION
Low-cost, mostly built-in upgrades that close real gaps in the opencode workflow. No new MCP servers — the wins come from opencode's own tools plus a global rules file that steers the agent to the right one.

### Changes
- **zshenv**: `OPENCODE_ENABLE_EXA=1` turns on the built-in `websearch` (Exa, free, no API key). Required when not on the opencode provider; without it only `webfetch` is available, so the agent can discover URLs instead of only reading known ones.
- **opencode.json**: `lsp:true` for diagnostic feedback (lua-ls/clangd auto-install; Python needs a manual `pyright`). `permission` adds safety gates — `rm` and force-push prompt, everything else stays at the permissive default; `codegraph_*` is documented as allowed.
- **config/opencode/AGENTS.md**: new global rules file, symlinked to `~/.config/opencode/AGENTS.md` and applied to **every** opencode session. Covers:
  - **Web-fetching fallback strategy**: `context7` for lib docs, Jina Reader proxy (`https://r.jina.ai/<url>`) for generic SPAs, `gh`/raw URLs for GitHub, `websearch` for discovery. Fixes the recurring "webfetch returns empty" failure mode on JS-rendered docs sites.
  - **MCP usage priority**: `context7` first for framework docs, `codegraph` first for code structure in indexed projects (fall back to built-ins when no `.codegraph/`).
- **AGENTS.md**: sync the OpenCode section to three managed files and document the websearch env, lsp, and permission changes.

### Why no new MCP servers
Several popular MCP servers are redundant given opencode's built-ins + this repo's existing tools:
- GitHub MCP → already covered by `gh` CLI + bash
- Brave/Tavily Search MCP → covered by built-in `websearch` (Exa)
- Sequential Thinking → covered by plan mode + `task` subagents
- Filesystem → covered by read/write/edit/glob/grep

### Post-merge steps (manual)
1. Restart opencode so `websearch`, LSP, and the global rules load.
2. (Python projects only) `npm install -g pyright` for Python LSP diagnostics — without it Python projects simply get no LSP feedback, other languages are unaffected.
3. The global rules apply automatically everywhere; project `AGENTS.md` files layer on top and take precedence.