### PR TITLE
fix(zsh): autoload fpath functions so occm/ocpr are callable

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -84,6 +84,14 @@ plugins=(
 
 source $ZSH/oh-my-zsh.sh
 
+# Autoload every function in $DOTFILES/zsh/functions (occm, ocpr, ...).
+# fpath is set in zshenv; this declares them callable as commands. Files
+# beginning with _ or . are skipped — _-prefixed are completion functions
+# handled by compinit, and .-prefixed are internal helpers.
+if [[ -d "$DOTFILES/zsh/functions" ]]; then
+  autoload -Uz $DOTFILES/zsh/functions/[^_.]*(:t)
+fi
+
 # User configuration
 
 # export MANPATH="/usr/local/man:$MANPATH"


### PR DESCRIPTION
### Problem
`occm` and `ocpr` (in `zsh/functions/`) fail with `command not found` in a fresh shell, despite the directory being on `fpath` via `zshenv.symlink`.

### Root cause
`fpath` membership alone doesn't make functions callable — zsh also requires an `autoload` declaration. This declaration was never present in `zshrc.symlink` (not at the fork, not after). The original author's `g`/`md`/`h`/`c` *appeared* to work only because oh-my-zsh aliases of the same name shadowed the fpath files; the real fpath functions (`prepend_path`, `last_modified`, ...) were dead code, and the recently added `occm`/`ocpr` hit `command not found`.

Not an upstream regression — the upstream stow refactor (`c7c2cd6`) only lives in `remotes/upstream/*`, never merged into this fork's `main`.

### Fix
Add the missing `autoload` after `source $ZSH/oh-my-zsh.sh`. Skip `_`-prefixed files (completion functions, handled by `compinit`) and `.`-prefixed (internal helpers).

```zsh
if [[ -d "$DOTFILES/zsh/functions" ]]; then
  autoload -Uz $DOTFILES/zsh/functions/[^_.]*(:t)
fi
```

### Verification
- `zsh -n zsh/zshrc.symlink` — syntax OK
- Fresh interactive shell: `whence -w occm` → `occm: function`, `whence -w ocpr` → `ocpr: function` (were `none` before)

### Post-merge
Run `exec zsh` (or open a new terminal) — `occm` and `ocpr` become callable immediately.