### PR TITLE
fix(nvim,opencode): remove hardcoded machine-specific paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 npm-debug.log
 config/nvim/spell
 config/nvim/shada
+config/nvim/lua/local.lua
 vim/vim.symlink/spell/
 vim/vim.symlink/plugged/
 Brewfile.lock.json

--- a/config/nvim/lua/local.lua.example
+++ b/config/nvim/lua/local.lua.example
@@ -1,0 +1,14 @@
+-- Machine-local Neovim overrides — NOT committed (gitignored).
+-- Copy to local.lua and edit. Loaded via `pcall(require, "local")` from
+-- astrolsp.lua and any other config that opts into local overrides.
+
+return {
+    -- Extra clangd --query-driver paths for cross-compilers on this machine.
+    -- These are appended to the portable defaults (gcc-13, gcc, gcc-11) in
+    -- astrolsp.lua's clangd config.
+    clangd_query_drivers = {
+        -- Example: ARM embedded cross-compiler via vcpkg
+        -- "/home/<user>/.vcpkg/downloads/artifacts/<hash>/compilers.arm.arm.none.eabi.gcc/14.2.1/bin/arm-none-eabi-gcc",
+        -- "/usr/bin/arm-none-eabi-gcc",
+    },
+}

--- a/config/nvim/lua/plugins/astrolsp.lua
+++ b/config/nvim/lua/plugins/astrolsp.lua
@@ -47,16 +47,31 @@ return {
         config = {
             clangd = {
                 capabilities = { offsetEncoding = "utf-8" },
-                cmd = {
-                    "clangd",
-                    "--query-driver=/home/linuxbrew/.linuxbrew/bin/gcc-13,/usr/bin/gcc,/usr/bin/gcc-11,/home/wl_ubuntu/.vcpkg/downloads/artifacts/2139c4c6/compilers.arm.arm.none.eabi.gcc/14.2.1/bin/arm-none-eabi-gcc,/usr/bin/arm-none-eabi-gcc,/usr/bin/arm-none-eabi-gcc",
-                    "--limit-references=0",
-                    "--limit-results=1000",
-                    "--pch-storage=memory",
-                    "-j=2",
-                    "--header-insertion=iwyu",
-                    -- "--log=verbose",
-                },
+                cmd = (function()
+                    -- Portable query-driver list; machine-specific cross-compile
+                    -- paths (e.g. arm-none-eabi-gcc under vcpkg) are merged in from
+                    -- an optional local override at config/nvim/lua/local.lua
+                    -- (gitignored). See local.lua.example for a template.
+                    local drivers = {
+                        "/home/linuxbrew/.linuxbrew/bin/gcc-13",
+                        "/usr/bin/gcc",
+                        "/usr/bin/gcc-11",
+                    }
+                    local ok, local_cfg = pcall(require, "local")
+                    if ok and local_cfg then
+                        vim.list_extend(drivers, local_cfg.clangd_query_drivers or {})
+                    end
+                    return {
+                        "clangd",
+                        "--query-driver=" .. table.concat(drivers, ","),
+                        "--limit-references=0",
+                        "--limit-results=1000",
+                        "--pch-storage=memory",
+                        "-j=2",
+                        "--header-insertion=iwyu",
+                        -- "--log=verbose",
+                    }
+                end)(),
             },
             lua_ls = {
                 settings = {

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -26,10 +26,9 @@
   "formatter": {
     "clang-format": {
       "command": [
-        "clang-format",
-        "--style=file:/home/wl_ubuntu/.config/nvim/.clang-format",
-        "-i",
-        "$FILE"
+        "sh",
+        "-c",
+        "clang-format --style=file:\"$HOME/.config/nvim/.clang-format\" -i \"$FILE\""
       ],
       "extensions": ["c", "cpp", "h", "hpp", "cc", "cxx"]
     }


### PR DESCRIPTION
Two committed configs contained absolute paths specific to one machine, breaking portability to any other user/host.

### Changes
- **opencode.json (HIGH)**: the clang-format formatter hardcoded `/home/wl_ubuntu/.config/nvim/.clang-format`. opencode's `command` array is exec'd directly (no shell), so `$HOME` wouldn't expand. Wrapped with `sh -c` so `$HOME` expands at runtime; `$FILE` is still replaced by opencode before exec.
- **astrolsp.lua (HIGH)**: clangd's `--query-driver` hardcoded a vcpkg artifact path (with a hash `2139c4c6` that changes on update) plus a triplicate `arm-none-eabi-gcc`. Kept only portable drivers (`gcc-13`, `gcc`, `gcc-11`) in the repo; machine-specific cross-compile paths now merge from an optional local override via `pcall(require, "local")`.

### New files
- `config/nvim/lua/local.lua.example` — template for the local override (copy to `local.lua`, which is gitignored).
- `.gitignore` — added `config/nvim/lua/local.lua`.

### Post-merge (if you use cross-compilers)
Copy the template and fill in your paths:
```sh
cp config/nvim/lua/local.lua.example config/nvim/lua/local.lua
# edit local.lua, uncomment/fill clangd_query_drivers
```